### PR TITLE
Restore format-on-save functionality

### DIFF
--- a/dart-server.el
+++ b/dart-server.el
@@ -1372,6 +1372,11 @@ this can be overridden by customizing
       (kill-buffer patch-buffer)
       (delete-file file))))
 
+(defun dart-server--do-format-on-save ()
+  "Format the buffer if `dart-server-format-on-save' is non-nil."
+  (when dart-server-format-on-save
+    (dart-server-format)))
+
 (defun dart-server--apply-rcs-patch (patch-buffer)
   "Apply an RCS diff from PATCH-BUFFER to the current buffer."
   (let ((target-buffer (current-buffer))
@@ -1438,7 +1443,10 @@ This replaces references to TEMP-FILE with REAL-FILE."
 ;;; Initialization
 
 ;;;###autoload
-(define-minor-mode dart-server nil)
+(define-minor-mode dart-server nil nil nil nil
+  (if dart-server
+      (add-hook 'before-save-hook #'dart-server--do-format-on-save nil t)
+    (remove-hook 'before-save-hook #'dart-server--do-format-on-save t)))
 
 (provide 'dart-server)
 


### PR DESCRIPTION
In the move to the new repo, the format-on-save functionality got left out.

Currently, `dart-server-format-on-save` is defined but unused. It was previously used like so:
https://github.com/bradyt/dart-mode/blob/e41f41e09cfeb35f3733f07c06ee8037825fb5ab/dart-mode.el#L2041

This patch restores the functionality, with some tweaks:

1. Define a named function for performing the conditional format, so we can remove it from the hook when deactivating the minor mode
2. Use the `LOCAL` argument of `add-hook` to make the `before-save-hook` buffer-local